### PR TITLE
push old tx when join room

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "docs:dev": "DEBUG_ON=true nodemon swagger.js",
         "docs": "node swagger.js",
         "test": "jest --verbose",
-        "test:watch": "jest --watch --verbose"
+        "test:watch": "jest --watch --verbose",
+        "test:server": "jest --verbose src/server.test.js"
     },
     "author": "jeffwscott",
     "license": "ISC",

--- a/src/endponts/blocks.test.js
+++ b/src/endponts/blocks.test.js
@@ -59,7 +59,6 @@ describe('Test Blocks Endpoints', () => {
             const item = response.body[0];
             validBlock(item)
 
-            console.log(response.body)
             expect(item.number).toBe(blocknum);
         })
 

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -29,7 +29,7 @@ describe("Testing websocket server.", () => {
     clientSocket.disconnect();
   });
 
-  test("Subscribe to the new-state-changes-by-transaction event in tx hash room ", (done) => {
+  test("Tx not existing: Subscribe to the new-state-changes-by-transaction event in tx hash room ", (done) => {
     let data = newblock[0]
     clientSocket.once("new-block", (msg) => {
       let message = JSON.parse(msg).message
@@ -54,6 +54,25 @@ describe("Testing websocket server.", () => {
     blockProcessor(data).catch((e) => { console.log(e) })
   });
 
+  test("Tx already existing: Subscribe to the new-state-changes-by-transaction event in tx hash room ", (done) => {
+    let data = newblock[0]
+    clientSocket.once("new-state-changes-by-transaction", (msg) => {
+      let message = JSON.parse(msg).message
+      expect(getType(message)).toBe('object')
+      expect(getType(message.hlc_timestamp)).toBe('string')
+      expect(getType(message.blockNum)).toBe('string')
+      expect(message.blockNum).toBeDefined()
+      expect(message.affectedContractsList).toBeDefined()
+      expect(message.affectedVariablesList).toBeDefined()
+      expect(message.affectedRootKeysList).toBeDefined()
+      //expect(message.affectedRawKeysList).toBeDefined()
+      expect(message.state_changes_obj).toBeDefined()
+      //expect(message.txHash).toBeDefined()
+      expect(message.txInfo).toBeDefined()
+      done()
+    });
+    clientSocket.emit('join', data.processed.hash)
+  });
 
   test("Should get push notifications of new block after a new block was processed.", (done) => {
     let data = newblock[1]
@@ -80,33 +99,8 @@ describe("Testing websocket server.", () => {
     blockProcessor(data).catch((e) => { console.log(e) })
   });
 
-  test("Subscribe to the new-state-changes-by-transaction event in tx hash room ", (done) => {
-    let data = newblock[2]
-    clientSocket.once("new-block", (msg) => {
-      let message = JSON.parse(msg).message
-      expect(message).toEqual(data)
-    });
-    clientSocket.once("new-state-changes-by-transaction", (msg) => {
-      let message = JSON.parse(msg).message
-      expect(getType(message)).toBe('object')
-      expect(getType(message.blockNum)).toBe('string')
-      expect(message.blockNum).toBeDefined()
-      expect(message.affectedContractsList).toBeDefined()
-      expect(message.affectedVariablesList).toBeDefined()
-      expect(message.affectedRootKeysList).toBeDefined()
-      //expect(message.affectedRawKeysList).toBeDefined()
-      expect(message.state_changes_obj).toBeDefined()
-      //expect(message.txHash).toBeDefined()
-      expect(message.txInfo).toBeDefined()
-      done()
-    });
-    clientSocket.emit('join', data.processed.hash)
-    blockProcessor(data).catch((e) => { console.log(e) })
-  });
-
-
   test("Subscribe to new_reward event in rewards room ", (done) => {
-    let data = newblock[3]
+    let data = newblock[2]
     clientSocket.once("new_reward", (msg) => {
       let message = JSON.parse(msg).message
       expect(getType(message)).toBe('object')
@@ -121,7 +115,7 @@ describe("Testing websocket server.", () => {
   });
 
   test("Subscribe to the total_rewards event in rewards room ", (done) => {
-    let data = newblock[4]
+    let data = newblock[3]
     clientSocket.once("total_rewards", (msg) => {
       let message = JSON.parse(msg).message
       expect(message.amount).toBeDefined()
@@ -132,7 +126,7 @@ describe("Testing websocket server.", () => {
   });
 
   test("Subscribe to the new_reward event in recipient rewards room ", (done) => {
-    let data = newblock[5]
+    let data = newblock[4]
     clientSocket.once("new_reward", (msg) => {
       let message = JSON.parse(msg).message
       expect(getType(message)).toBe('object')
@@ -160,5 +154,6 @@ describe("Testing websocket server.", () => {
     clientSocket.emit('join', "rewards-masternodes")
     blockProcessor(data).catch((e) => { console.log(e) })
   });
+
 
 });


### PR DESCRIPTION
When someone joins the tx hash room, if the tx exists in the database, push the old tx.

this feature will solve this issue：
a block(tx) has been processed by block service => someone join the tx room => fail to get the tx result..